### PR TITLE
Adding batch size to parameters in train function (Yolo V2)

### DIFF
--- a/hot_fair_utilities/training/yolo_v8_v2/train.py
+++ b/hot_fair_utilities/training/yolo_v8_v2/train.py
@@ -102,6 +102,7 @@ def train(
         ),  # Using the environment variable with fallback
         name=name,
         epochs=int(epochs),
+        batch = int(batch_size),
         resume=resume,
         verbose=True,
         deterministic=False,


### PR DESCRIPTION
To @kshitijrajsharma attention!
I have created this branch to modify the parameters of the Yolo training, that in the current version are missing the batch size (unintentionally).
I assume you want to add this to the V1 code too.
Best!