### PR TITLE
Fix #48: reproject label coordinates to chip CRS before YOLO normalization

### DIFF
--- a/hot_fair_utilities/preprocessing/yolo_v8/utils.py
+++ b/hot_fair_utilities/preprocessing/yolo_v8/utils.py
@@ -148,6 +148,44 @@ def convert_coordinates(coordinates, geo_dict):
     return coordinates
 
 
+def _geojson_crs(data, default="EPSG:4326"):
+    """Return the CRS of a GeoJSON object.
+
+    GeoJSON (RFC 7946) is WGS84 / EPSG:4326 by default, but tiles produced earlier in the
+    fAIr pipeline can carry a named-CRS member (e.g. EPSG:3857). We honour that member when
+    present and fall back to the spec default otherwise.
+    """
+    try:
+        name = data["crs"]["properties"]["name"]
+    except (KeyError, TypeError):
+        return default
+    if name and "EPSG" in name.upper():
+        code = name.replace("::", ":").split(":")[-1]
+        return f"EPSG:{code}"
+    return name or default
+
+
+def reproject_coordinates(coordinates, src_crs, dst_crs):
+    """Reproject nested polygon coordinates from ``src_crs`` to ``dst_crs``.
+
+    Fixes #48: chip corners (from the GeoTIFF) and label polygon points (from GeoJSON) can be
+    in different CRS. Without this, ``convert_coordinates`` subtracts/divides values from two
+    coordinate systems, producing out-of-range numbers that ``check_and_clamp`` pins to 0/1 —
+    i.e. labels "collapse to wrong pixels". A no-op when the two CRS already match.
+    """
+    if src_crs == dst_crs:
+        return coordinates
+    transformer = Transformer.from_crs(src_crs, dst_crs, always_xy=True)
+    reprojected = []
+    for ring in coordinates:
+        new_ring = []
+        for point in ring:
+            x, y = transformer.transform(point[0], point[1])
+            new_ring.append([x, y])
+        reprojected.append(new_ring)
+    return reprojected
+
+
 def write_yolo_file(iwp, folder, output_path, class_index=0):
     """
     Writes YOLO label file based on the given image with path and class index.
@@ -180,6 +218,9 @@ def write_yolo_file(iwp, folder, output_path, class_index=0):
     with open(lwp) as file:
         data = json.load(file)
 
+    # CRS of the label geometries (fixes #48: may differ from the chip's CRS)
+    label_crs = _geojson_crs(data)
+
     # Initialize the polygon count
     polygon_count = 0
 
@@ -191,6 +232,9 @@ def write_yolo_file(iwp, folder, output_path, class_index=0):
 
             # Get the coordinates of the polygon
             coordinates = feature["geometry"]["coordinates"]
+
+            # Reproject label points into the chip's CRS before normalizing (fixes #48)
+            coordinates = reproject_coordinates(coordinates, label_crs, geo_dict["crs"])
 
             # Convert the coordinates
             new_coordinates = flatten_list(convert_coordinates(coordinates, geo_dict))

--- a/test_yolo_label_crs.py
+++ b/test_yolo_label_crs.py
@@ -1,0 +1,70 @@
+"""Regression test for #48 — YOLO labels collapse to wrong pixels on CRS mismatch.
+
+Verifies that reproject_coordinates() makes label normalization correct when the label
+GeoJSON and the chip are in different coordinate reference systems.
+
+Note: importing hot_fair_utilities pulls in rasterio/pyproj (project dependencies), so this
+runs under the project's normal test environment / CI.
+"""
+import pytest
+
+pyproj = pytest.importorskip("pyproj")
+from pyproj import Transformer
+
+from hot_fair_utilities.preprocessing.yolo_v8.utils import (
+    convert_coordinates,
+    flatten_list,
+    reproject_coordinates,
+)
+
+# A small chip in EPSG:4326, as get_geo_data() would report it.
+GEO_DICT = {
+    "crs": "EPSG:4326",
+    "left": 45.3200, "right": 45.3210, "top": 2.0410, "bottom": 2.0400,
+    "width": 0.0010, "height": 0.0010,
+}
+# A building polygon inside the chip, expressed in the chip's CRS (4326).
+POLY_4326 = [[
+    [45.3203, 2.0407], [45.3206, 2.0407], [45.3206, 2.0404], [45.3203, 2.0404], [45.3203, 2.0407],
+]]
+
+
+def _deep(poly):
+    return [[list(pt) for pt in ring] for ring in poly]
+
+
+def _to_3857(poly):
+    tf = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
+    return [[list(tf.transform(x, y)) for (x, y) in ring] for ring in poly]
+
+
+def _pct_on_boundary(coords):
+    flat = flatten_list(coords)
+    return sum(1 for v in flat if v in (0, 1)) / len(flat)
+
+
+def test_matched_crs_is_correct():
+    out = convert_coordinates(_deep(POLY_4326), GEO_DICT)
+    assert _pct_on_boundary(out) == 0.0
+    assert out[0][0] == [0.3, 0.3]
+
+
+def test_mismatched_crs_collapses_without_reprojection():
+    # Reproduces the bug: 3857 label points against a 4326 chip collapse to 0/1.
+    out = convert_coordinates(_to_3857(POLY_4326), GEO_DICT)
+    assert _pct_on_boundary(out) == 1.0  # every point pinned to a boundary -> useless labels
+
+
+def test_reprojection_fixes_collapse():
+    # The fix: reproject labels into the chip CRS first; result matches the matched-CRS case.
+    reproj = reproject_coordinates(_to_3857(POLY_4326), "EPSG:3857", GEO_DICT["crs"])
+    out = convert_coordinates(reproj, GEO_DICT)
+    expected = convert_coordinates(_deep(POLY_4326), GEO_DICT)
+    assert _pct_on_boundary(out) == 0.0
+    for got, exp in zip(flatten_list(out), flatten_list(expected)):
+        assert abs(got - exp) < 1e-3
+
+
+def test_reproject_is_noop_when_crs_match():
+    poly = _deep(POLY_4326)
+    assert reproject_coordinates(poly, "EPSG:4326", "EPSG:4326") == poly


### PR DESCRIPTION
## What
Fixes #48 — YOLO labels can collapse to wrong pixels (all 0/1).

## Root cause
When the label GeoJSON and the image chip are in **different coordinate reference systems**, `convert_coordinates()` subtracts/divides values from two CRS at once. The result lands far outside `[0,1]`, and `check_and_clamp()` pins every point to a boundary — so labels collapse to the wrong pixels and are useless for training.

## Fix
Reproject the label polygon points into the chip's CRS **before** normalizing, using `pyproj` (already a project dependency). The label CRS is read from the GeoJSON named-CRS member, defaulting to `EPSG:4326` per RFC 7946. The reprojection is a **no-op when the two CRS already match**, so existing behavior is unchanged.

## Tests
Adds `test_yolo_label_crs.py` covering three cases: matched-CRS is correct, mismatched-CRS reproduces the collapse, and reprojection restores correct coordinates. (Uses `pytest.importorskip("pyproj")`.)

## Note
While here, I noticed the non-4326 `else` branch in `convert_coordinates()` (utils.py) appears to swap the axis normalization (x by height, y by width). I left it **out of scope** for this PR since it needs separate confirmation of `get_geo_data()`'s non-4326 semantics — flagging it in case it's a real secondary bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
